### PR TITLE
Add update-ipsets to Firehol for redhat package

### DIFF
--- a/build-redhat.sh
+++ b/build-redhat.sh
@@ -21,8 +21,6 @@ FIREHOL_MD5=`cut -f1 -d' ' < build/firehol.md5`
 IPRANGE_MD5=`cut -f1 -d' ' < build/iprange.md5`
 NETDATA_MD5=`cut -f1 -d' ' < build/netdata.md5`
 
-IPRANGE_RELEASE="1"
-
 for v in 6 7
 do
   mkdir -p build/el${v}
@@ -45,12 +43,12 @@ do
   cp ../iprange-$IPRANGE_VERSION.tar.bz2 iprange/rpmbuild/SOURCES
   cp ../netdata-$NETDATA_VERSION.tar.bz2 netdata/rpmbuild/SOURCES
 
-  sed -i -e "s;<<VER>>;$FIREHOL_VERSION;" -e "s;<<URL>>;$FIREHOL_URL;" -e "s;<<MD5>>;$FIREHOL_MD5;" firehol/firehol.spec
+  sed -i -e "s;<<VER>>;$FIREHOL_VERSION;" -e "s;<<URL>>;$FIREHOL_URL;" -e "s;<<MD5>>;$FIREHOL_MD5;" -e "/Release:/s/%.*/$RPM_FIREHOL_RELEASE%{?dist}/" firehol/firehol.spec
   tar xfj ../iprange-$IPRANGE_VERSION.tar.bz2 iprange-$IPRANGE_VERSION/iprange.spec
   mv iprange-$IPRANGE_VERSION/iprange.spec iprange/iprange.spec
   rmdir iprange-$IPRANGE_VERSION
   sed -i -e "s;_sbindir;_bindir;" -e '/^%files/a\
-%{_mandir}/man1/iprange.1.gz' -e "/Release:/s/%.*/1%{?dist}/" -e "/BuildRoot:/d" iprange/iprange.spec
+%{_mandir}/man1/iprange.1.gz' -e "/Release:/s/%.*/$RPM_IPRANGE_RELEASE%{?dist}/" -e "/BuildRoot:/d" iprange/iprange.spec
   tar xfj ../netdata-$NETDATA_VERSION.tar.bz2 netdata-$NETDATA_VERSION/netdata.spec
   mv netdata-$NETDATA_VERSION/netdata.spec netdata/netdata.spec
   rmdir netdata-$NETDATA_VERSION
@@ -81,7 +79,7 @@ do
   sudo docker run -v `pwd`:/fh-build/centos${v}:rw firehol-package-centos${v} \
               /bin/bash /fh-build/centos${v}/iprange/docker-build.sh
   sudo docker run -v `pwd`:/fh-build/centos${v}:rw firehol-package-centos${v} \
-              /bin/bash -c "yum install -y /fh-build/centos${v}/iprange/rpmbuild/RPMS/x86_64/iprange-$IPRANGE_VERSION-$IPRANGE_RELEASE.el${v}.x86_64.rpm && /bin/bash /fh-build/centos${v}/firehol/docker-build.sh"
+              /bin/bash -c "yum install -y /fh-build/centos${v}/iprange/rpmbuild/RPMS/x86_64/iprange-$IPRANGE_VERSION-$RPM_IPRANGE_RELEASE.el${v}.x86_64.rpm && /bin/bash /fh-build/centos${v}/firehol/docker-build.sh"
   sudo docker run -v `pwd`:/fh-build/centos${v}:rw firehol-package-centos${v} \
               /bin/bash /fh-build/centos${v}/netdata/docker-build.sh
   cd ../..

--- a/build-redhat.sh
+++ b/build-redhat.sh
@@ -21,6 +21,8 @@ FIREHOL_MD5=`cut -f1 -d' ' < build/firehol.md5`
 IPRANGE_MD5=`cut -f1 -d' ' < build/iprange.md5`
 NETDATA_MD5=`cut -f1 -d' ' < build/netdata.md5`
 
+IPRANGE_RELEASE="1"
+
 for v in 6 7
 do
   mkdir -p build/el${v}
@@ -77,9 +79,9 @@ do
     sudo docker rmi firehol-package-centos${v}-new
   fi
   sudo docker run -v `pwd`:/fh-build/centos${v}:rw firehol-package-centos${v} \
-              /bin/bash /fh-build/centos${v}/firehol/docker-build.sh
-  sudo docker run -v `pwd`:/fh-build/centos${v}:rw firehol-package-centos${v} \
               /bin/bash /fh-build/centos${v}/iprange/docker-build.sh
+  sudo docker run -v `pwd`:/fh-build/centos${v}:rw firehol-package-centos${v} \
+              /bin/bash -c "yum install -y /fh-build/centos${v}/iprange/rpmbuild/RPMS/x86_64/iprange-$IPRANGE_VERSION-$IPRANGE_RELEASE.el${v}.x86_64.rpm && /bin/bash /fh-build/centos${v}/firehol/docker-build.sh"
   sudo docker run -v `pwd`:/fh-build/centos${v}:rw firehol-package-centos${v} \
               /bin/bash /fh-build/centos${v}/netdata/docker-build.sh
   cd ../..

--- a/package.conf
+++ b/package.conf
@@ -8,3 +8,6 @@ IPRANGE_URL=https://github.com/firehol/iprange/releases/download/v$IPRANGE_VERSI
 
 NETDATA_VERSION=1.10.0
 NETDATA_URL=https://github.com/firehol/netdata/releases/download/v$NETDATA_VERSION
+
+RPM_IPRANGE_RELEASE="2"
+RPM_FIREHOL_RELEASE="2"

--- a/redhat/firehol/firehol.spec
+++ b/redhat/firehol/firehol.spec
@@ -13,6 +13,7 @@ Source1:        firehol.service
 Source2:        fireqos.service
 %endif
 BuildArch:      noarch
+BuildRequires:  iprange
 BuildRequires:  iproute
 BuildRequires:  ipset
 BuildRequires:  iptables
@@ -63,7 +64,6 @@ on all interfaces.
 %build
 %configure \
 	--disable-link-balancer \
-	--disable-update-ipsets \
 	--disable-vnetbuild
 make %{?_smp_mflags}
 
@@ -73,8 +73,10 @@ make %{?_smp_mflags} install DESTDIR="%{buildroot}"
 # Fixup the symlinks manually
 rm %{buildroot}/usr/sbin/firehol
 rm %{buildroot}/usr/sbin/fireqos
+rm %{buildroot}/usr/sbin/update-ipsets
 ln -s %{_libexecdir}/firehol/%{version}/firehol %{buildroot}/usr/sbin
 ln -s %{_libexecdir}/firehol/%{version}/fireqos %{buildroot}/usr/sbin
+ln -s %{_libexecdir}/firehol/%{version}/update-ipsets %{buildroot}/usr/sbin
 
 %if 0%{?rhel} > 0 && 0%{?rhel} < 7
 mkdir -p %{buildroot}%{_initrddir}
@@ -146,16 +148,19 @@ fi
 %endif
 %{_sbindir}/firehol
 %{_sbindir}/fireqos
+%{_sbindir}/update-ipsets
 %{_docdir}/firehol/html/*
 %{_docdir}/firehol/contrib/*
 %{_docdir}/firehol/examples/*
 %{_docdir}/firehol/*.pdf
 %{_mandir}/man1/*.1*
 %{_mandir}/man5/*.5*
+%{_datadir}/update-ipsets/webdir/*
 %dir %{_sysconfdir}/firehol/services/
 %{_localstatedir}/spool/firehol
 %{_libexecdir}/firehol/%{version}/firehol
 %{_libexecdir}/firehol/%{version}/fireqos
+%{_libexecdir}/firehol/%{version}/update-ipsets
 %{_libexecdir}/firehol/%{version}/functions.common
 %{_libexecdir}/firehol/%{version}/install.config
 %{_libexecdir}/firehol/%{version}/services.common
@@ -163,5 +168,7 @@ fi
 %{_libexecdir}/firehol/%{version}/services.fireqos
 
 %changelog
+* Sat Feb 15 2020 John Ramsden <johnramsden@riseup.net>
+- Enable update-ipsets
 * Thu Jan 19 2017 Phil Whineray <phil@firehol.org> - 3.1.1-1
 - Imported from final RedHat version, updated for v3.1.1 package

--- a/redhat/firehol/firehol.spec
+++ b/redhat/firehol/firehol.spec
@@ -168,7 +168,7 @@ fi
 %{_libexecdir}/firehol/%{version}/services.fireqos
 
 %changelog
-* Sat Feb 15 2020 John Ramsden <johnramsden@riseup.net>
+* Sat Feb 15 2020 John Ramsden <johnramsden@riseup.net> - 3.1.1-2
 - Enable update-ipsets
 * Thu Jan 19 2017 Phil Whineray <phil@firehol.org> - 3.1.1-1
 - Imported from final RedHat version, updated for v3.1.1 package


### PR DESCRIPTION
## Summary

Add update-ipsets to the package redhat version of Firehol.

## Changes

* Build now requires iprange
* Add update-ipsets files to package
* Change spec

## Tests

* Ran build successfully
* Installed and tested on centos 6

## Notes

To install iprange I changed the order in the package building to build iprange first and installed the iprange package into the container before running the build. I wasn't sure if this was the best way to do it, or if there was a preferred alternative.

I set the iprange "Release" with `IPRANGE_RELEASE="1"`, as I wasn't sure how to get the release version dynamically, or if it would end up changing at all. The release versions appear to be hard-coded to 1 in the spec files, so maybe that will never change anyway.