### PR TITLE
Add build support for EL8 and EL9

### DIFF
--- a/build-redhat.sh
+++ b/build-redhat.sh
@@ -20,7 +20,7 @@ fi
 FIREHOL_MD5=`cut -f1 -d' ' < build/firehol.md5`
 IPRANGE_MD5=`cut -f1 -d' ' < build/iprange.md5`
 
-for v in 7
+for v in 7 8 9
 do
   mkdir -p build/el${v}
   cd build/el${v}
@@ -52,7 +52,12 @@ do
     #   sudo docker rm -v $(sudo docker ps -a -q -f status=exited)
     #   sudo docker rmi firehol-package-centos6
     #   sudo docker rmi firehol-package-centos7
-    sudo docker run -v `pwd`:/fh-build/centos${v}:rw centos:centos${v} \
+    BASE_IMAGE_NAME="centos:centos{$v}"
+    if [ "${v}" != "7" ]
+    then
+      BASE_IMAGE_NAME="rockylinux:${v}"
+    fi
+    sudo docker run -v `pwd`:/fh-build/centos${v}:rw ${BASE_IMAGE_NAME} \
                 /bin/bash /fh-build/centos${v}/docker-setup.sh
     id=`sudo docker ps -l -q`
     sudo docker commit $id firehol-package-centos${v}

--- a/redhat/docker-setup.sh
+++ b/redhat/docker-setup.sh
@@ -6,4 +6,10 @@ set -e
 yum install -y rpm-build make gcc automake autoconf
 
 # FireHOL dependencies
-yum install -y iproute ipset iptables iptables-ipv6 tcpdump systemd zlib-devel libuuid-devel
+MAJOR_VERSION=`cat /etc/redhat-release | grep -o -P '[0-9]+\.' | head -n 1 | grep -o -P '[0-9]+'`
+if [ "${MAJOR_VERSION}" == "7" ]
+then
+	yum install -y iproute ipset iptables iptables-ipv6 tcpdump systemd zlib-devel libuuid-devel
+else
+	yum install -y iproute ipset iptables-services kmod tcpdump systemd zlib-devel libuuid-devel procps-ng iproute-tc
+fi

--- a/redhat/firehol/firehol.spec
+++ b/redhat/firehol/firehol.spec
@@ -16,8 +16,15 @@ BuildArch:      noarch
 BuildRequires:  iprange
 BuildRequires:  iproute
 BuildRequires:  ipset
+%if 0%{?rhel} > 0 && 0%{?rhel} < 7
 BuildRequires:  iptables
 BuildRequires:  iptables-ipv6
+BuildRequires:  procps-ng
+BuildRequires:	iproute-tc
+%else
+BuildRequires:  iptables-services
+BuildRequires:	kmod
+%endif
 BuildRequires:  tcpdump
 %if 0%{?rhel} > 0 && 0%{?rhel} < 7
 %else
@@ -29,8 +36,15 @@ Requires:       grep
 Requires:       gzip
 Requires:       ipset
 Requires:       iproute
+%if 0%{?rhel} > 0 && 0%{?rhel} < 7
 Requires:       iptables
 Requires:       iptables-ipv6
+%else
+Requires:       iptables-services
+Requires:       kmod
+Requires:	procps-ng
+Requires:	iproute-tc
+%endif
 Requires:       less
 Requires:       sed
 Requires:       util-linux


### PR DESCRIPTION
This builds packages for CentOS/RHEL/Rocky/Alma 8 and 9.

Fixes #12

Installs and seems to work correctly on Rocky 9.  Have not tested installation on 8, but it does build.