### PR TITLE
Fix package release version

### DIFF
--- a/redhat/firehol/firehol.spec
+++ b/redhat/firehol/firehol.spec
@@ -1,6 +1,6 @@
 Name:           firehol
 Version:        <<VER>>
-Release:        1%{?dist}
+Release:        %{?dist}
 Summary:        Simple and powerful firewall and traffic shaping languages
 License:        GPLv2+
 URL:            http://firehol.org


### PR DESCRIPTION
Fixes #11 

The `%{?dist}` macro gets substituted out for `$RPM_FIREHOL_RELEASE%{?dist}` by `build-redhat.sh`, but the spec file contained an additional 1 that wasn't being replaced, resulting in a concatenation of "1" and whatever `$RPM_FIREHOL_RELEASE` is set to in `package.conf`.